### PR TITLE
Centralized watched helper integration

### DIFF
--- a/IPTVPlayer/hosts/hostfilmpalast.py
+++ b/IPTVPlayer/hosts/hostfilmpalast.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 20.07.2026 - HLS sidecar files (.txt + .jpg) extended, IMDb rating, Year and Genre added for descriptions/sidecar files,
-# MKV FFmpeg postprocess meta for HLSDownloader/WgetDownloader,
-# URL meta helper for sidecar and MKV postprocess handling - Kamikaze24
+# Last Modified: 05.08.2026 - Centralized watched helper integration incl. favourite hash sync - Kamikaze24
 ###################################################
 # LOCAL import
 ###################################################
@@ -13,6 +11,7 @@ from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.e2ijson import loads as json_loads
 from Plugins.Extensions.IPTVPlayer.libs import ph
 from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, sidecarFromUrlMeta, decorateUrl, decorateCachedLinkItems, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 
 ###################################################
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote
@@ -25,13 +24,18 @@ from Plugins.Extensions.IPTVPlayer.p2p3.UrlParse import urljoin
 
 config.plugins.iptvplayer.filmpalast_sidecar = ConfigYesNo(default=True)
 config.plugins.iptvplayer.filmpalast_mkv = ConfigYesNo(default=True)
+config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True)
 
 
 def GetConfigList():
-    return [
+    optionList = [
         getConfigListEntry(_("Create sidecar files (.txt/.jpg)") + ":", config.plugins.iptvplayer.filmpalast_sidecar),
-        getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.filmpalast_mkv)
+        getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.filmpalast_mkv),
+        getConfigListEntry(_("Allow watched flag to be set"), config.plugins.iptvplayer.favourites_use_watched_flag)
     ]
+    if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+        optionList.append(getConfigListEntry(_("The color of the viewed item"), config.plugins.iptvplayer.watched_item_color))
+    return optionList
 
 
 def gettytul():
@@ -54,6 +58,7 @@ class FilmPalastTo(CBaseHostClass):
         self.cacheSeries = {}
         self.cacheSeasons = {}
         self.cacheLinks = {}
+        self.watchedHelper = IPTVWatchedHelper('filmpalastto')
 
     def selectDomain(self):
         self.MAIN_URL = "https://filmpalast.to/"
@@ -87,6 +92,33 @@ class FilmPalastTo(CBaseHostClass):
             return ""
         cookieHeader = self.cm.getCookieHeader(self.COOKIE_FILE)
         return strwithmeta(url, {"Cookie": cookieHeader, "User-Agent": self.USER_AGENT})
+
+    def _getWatchedKeyForItem(self, cItem):
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            itemType = cItem.get("type", "")
+            category = cItem.get("category", "")
+            if itemType in ["video", "audio"]:
+                url = str(cItem.get("url", "") or "").strip()
+                if url != "":
+                    return "url:%s" % url
+                return ""
+            if category == "explore_item":
+                url = str(cItem.get("url", "") or "").strip()
+                if url != "":
+                    return "url:%s" % url
+                return ""
+            if category == "list_episodes":
+                baseUrl = str(cItem.get("url", "") or "").strip()
+                seasonId = str(cItem.get("f_season", "") or "").strip()
+                if baseUrl != "" and seasonId != "":
+                    return "season:%s|%s" % (baseUrl, seasonId)
+                return ""
+            return ""
+        except Exception:
+            printExc()
+        return ""
 
     def _listLinks(self, cItem, m1, m2):
         sts, data = self.getPage(cItem["url"])
@@ -197,6 +229,7 @@ class FilmPalastTo(CBaseHostClass):
 
             params = dict(cItem)
             params.update({"good_for_fav": True, "category": nextCategory, "title": title, "url": url, "icon": icon, "desc": desc})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addDir(params)
 
         if nextPage:
@@ -211,38 +244,38 @@ class FilmPalastTo(CBaseHostClass):
         for item in tab:
             params = dict(cItem)
             params.update(item)
+            params.pop("isWatched", None)
             # params['icon'] = self.getFullIconUrl('/files/movies/450/%s.jpg' % item['url'].split('/')[-1])
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
 
     def exploreItem(self, cItem, nextCategory):
         printDBG("FilmPalastTo.exploreItem")
-
         url = cItem["url"]
         sts, data = self.getPage(url)
         if not sts:
             return
-
         tmp = self.cm.ph.getDataBeetwenMarkers(data, '<ul class="staffelNav', "</ul>")[1]
-
         if 'data-id="staffId' not in data:
             params = dict(cItem)
+            params.pop("isWatched", None)
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
             return
-
         if "" != self.cm.ph.getSearchGroups(cItem["title"] + " ", r"""\s([Ss][0-9]+[Ee][0-9]+)\s""")[0]:
             params = dict(cItem)
+            params.pop("isWatched", None)
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
-
         self.cacheSeasons = {}
         seasonTitles = {}
-
+        seasonParams = {}
         tmp = self.cm.ph.getDataBeetwenMarkers(data, '<ul class="staffelNav', "</ul>")[1]
         tmp = self.cm.ph.getAllItemsBeetwenMarkers(tmp, "<li", "</li>")
         for item in tmp:
             seasonId = self.cm.ph.getSearchGroups(item, """data-id=['"]([^"^']+?)['"]""")[0]
             title = self.cleanHtmlStr(item)
             seasonTitles[seasonId] = title
-
         sp = '<div class="staffelWrapperLoop'
         tmp = self.cm.ph.getDataBeetwenMarkers(data, sp, '<a name="comments_view">', False)[1]
         tmp = tmp.split(sp)
@@ -257,9 +290,19 @@ class FilmPalastTo(CBaseHostClass):
                 if seasonId not in self.cacheSeasons:
                     self.cacheSeasons[seasonId] = []
                     params = dict(cItem)
+                    params.pop("isWatched", None)
                     params.update({"good_for_fav": False, "category": nextCategory, "title": seasonTitles.get(seasonId, seasonId), "f_season": seasonId})
+                    params["isWatched"] = False
+                    seasonParams[seasonId] = params
                     self.addDir(params)
-                self.cacheSeasons[seasonId].append({"good_for_fav": True, "title": title, "url": url})
+                episodeParams = {"good_for_fav": True, "title": title, "url": url, "type": "video"}
+                self.cacheSeasons[seasonId].append(episodeParams)
+                epKey = self._getWatchedKeyForItem(episodeParams)
+                if epKey != "" and self.watchedHelper.isWatched(epKey):
+                    seasonParams[seasonId]["isWatched"] = True
+                    seasonKey = self._getWatchedKeyForItem(seasonParams[seasonId])
+                    if seasonKey != "":
+                        self.watchedHelper.markItemWatched(seasonParams[seasonId], seasonKey)
 
     def listSearchResult(self, cItem, searchPattern, searchType):
         printDBG("FilmPalastTo.listSearchResult cItem[%s], searchPattern[%s] searchType[%s]" % (cItem, searchPattern, searchType))
@@ -269,6 +312,11 @@ class FilmPalastTo(CBaseHostClass):
 
     def getLinksForVideo(self, cItem):
         printDBG("FilmPalastTo.getLinksForVideo [%s]" % cItem)
+        try:
+            if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+                self.watchedHelper.markHostItemAsWatched(self, cItem, self._getWatchedKeyForItem)
+        except Exception:
+            printExc()
         linksTab = []
         sidecarTxt = ""
         sidecarImg = ""
@@ -398,7 +446,7 @@ class FilmPalastTo(CBaseHostClass):
             linksTab = _addFinalMeta(self.up.getVideoLinkExt(videoUrl))
 
         return linksTab
-
+    
     def getArticleContent(self, cItem):
         printDBG("FilmPalastTo.getArticleContent [%s]" % cItem)
         retTab = []
@@ -533,6 +581,57 @@ class IPTVHost(CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, FilmPalastTo(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('filmpalastto')
+
+    def getFavouriteHostName(self, index, displayItem):
+        return 'filmpalastto'
+
+    def fixWatchedFlag(self, ret):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+            ret = self.watchedHelper.fixHostRet(ret, self.host.currList, self.host._getWatchedKeyForItem, self.getFavouriteHostName)
+        self.cachedRet = ret
+        return ret
+
+    def syncWatchedToFavouriteHash(self, Index=0):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value and self.watchedHelper.syncFavouriteFromRet(self.cachedRet, Index, self.getFavouriteHostName):
+            self.refreshAfterWatchedFlagChange = True
+            return True
+        return False
+
+    def getLinksForVideo(self, Index=0, selItem=None):
+        try:
+            if config.plugins.iptvplayer.favourites_use_watched_flag.value and Index < len(self.host.currList):
+                self.watchedHelper.markHostItemAsWatched(self.host, self.host.currList[Index], self.host._getWatchedKeyForItem)
+        except Exception:
+            printExc()
+        try:
+            self.syncWatchedToFavouriteHash(Index)
+        except Exception:
+            printExc()
+        return CHostBase.getLinksForVideo(self, Index, selItem)
+
+    def getListForItem(self, Index=0, refresh=0, selItem=None):
+        ret = CHostBase.getListForItem(self, Index, refresh, selItem)
+        return self.fixWatchedFlag(ret)
+
+    def getPrevList(self, refresh=0):
+        ret = CHostBase.getPrevList(self, refresh)
+        return self.fixWatchedFlag(ret)
+
+    def getCurrentList(self, refresh=0):
+        if refresh == 1 and self.refreshAfterWatchedFlagChange and self.cachedRet is not None:
+            ret = self.cachedRet
+        else:
+            ret = CHostBase.getCurrentList(self, refresh)
+        ret = self.fixWatchedFlag(ret)
+        self.refreshAfterWatchedFlagChange = False
+        return ret
+
+    def getMoreForItem(self, Index=0):
+        ret = CHostBase.getMoreForItem(self, Index)
+        return self.fixWatchedFlag(ret)
 
     def withArticleContent(self, cItem):
         if "video" == cItem.get("type", "") or "explore_item" == cItem.get("category", ""):

--- a/IPTVPlayer/hosts/hostserienstreamto.py
+++ b/IPTVPlayer/hosts/hostserienstreamto.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 23.07.2026 - Kamikaze24 - Optional legacy title format added for old favorites/seen markers compatibility
+# Last Modified: 05.08.2026 - Centralized watched helper integration incl. favourite hash sync - Kamikaze24
 import re
 import json
 
@@ -12,6 +12,7 @@ from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
 from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc
 from Plugins.Extensions.IPTVPlayer.tools.iptvtypes import strwithmeta
 from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, sidecarFromUrlMeta, decorateUrl, decorateResolvedLinkItems
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 
 
 config.plugins.iptvplayer.serienstreamto_hosts = ConfigSelection(default="http://186.2.175.5/", choices=[("http://186.2.175.5/", "186.2.175.5"), ("https://serienstream.to/", "serienstream.to"), ("https://serienstream.cx/", "serienstream.cx")])  # NOSONAR
@@ -22,17 +23,22 @@ config.plugins.iptvplayer.serienstreamto_omdb_apikey = ConfigText(default="", fi
 config.plugins.iptvplayer.serienstreamto_sidecar = ConfigYesNo(default=True)
 config.plugins.iptvplayer.serienstreamto_mkv = ConfigYesNo(default=True)
 config.plugins.iptvplayer.serienstreamto_legacy_titles = ConfigYesNo(default=False)
+config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True)
 
 
 def GetConfigList():
-    return [getConfigListEntry(_("Use login") + ":", config.plugins.iptvplayer.serienstreamto_uselogin),
-            getConfigListEntry(_("e-mail") + ":", config.plugins.iptvplayer.serienstreamto_login),
-            getConfigListEntry(_("password") + ":", config.plugins.iptvplayer.serienstreamto_password),
-            getConfigListEntry(_("OMDb API Key") + ":", config.plugins.iptvplayer.serienstreamto_omdb_apikey),
-            getConfigListEntry(_("Create sidecar files (.txt/.jpg)") + ":", config.plugins.iptvplayer.serienstreamto_sidecar),
-            getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.serienstreamto_mkv),
-            getConfigListEntry(_("Use legacy title format") + ":", config.plugins.iptvplayer.serienstreamto_legacy_titles),
-            getConfigListEntry(_("host") + ":", config.plugins.iptvplayer.serienstreamto_hosts)]
+    optionList = [getConfigListEntry(_("Use login") + ":", config.plugins.iptvplayer.serienstreamto_uselogin),
+                  getConfigListEntry(_("e-mail") + ":", config.plugins.iptvplayer.serienstreamto_login),
+                  getConfigListEntry(_("password") + ":", config.plugins.iptvplayer.serienstreamto_password),
+                  getConfigListEntry(_("OMDb API Key") + ":", config.plugins.iptvplayer.serienstreamto_omdb_apikey),
+                  getConfigListEntry(_("Create sidecar files (.txt/.jpg)") + ":", config.plugins.iptvplayer.serienstreamto_sidecar),
+                  getConfigListEntry(_("Create MKV") + ":", config.plugins.iptvplayer.serienstreamto_mkv),
+                  getConfigListEntry(_("Use legacy title format") + ":", config.plugins.iptvplayer.serienstreamto_legacy_titles),
+                  getConfigListEntry(_("Allow watched flag to be set"), config.plugins.iptvplayer.favourites_use_watched_flag)]
+    if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+        optionList.append(getConfigListEntry(_("The color of the viewed item"), config.plugins.iptvplayer.watched_item_color))
+    optionList.append(getConfigListEntry(_("host") + ":", config.plugins.iptvplayer.serienstreamto_hosts))
+    return optionList
 
 
 def gettytul():
@@ -54,6 +60,7 @@ class SerienStreamTo(CBaseHostClass):
         self.DEFAULT_ICON_URL = "https://raw.githubusercontent.com/oe-mirrors/e2iplayer/gh-pages/Thumbnails/serienstream.to.png"
         self.imdb_cache = {}
         self.sessionEx = MainSessionWrapper()
+        self.watchedHelper = IPTVWatchedHelper('serienstreamto')
         self.MENU = [{"category": "list_items", "title": _("Series"), "url": self.getFullUrl("suche")},
                      {"category": "list_newepisodes", "title": "Neueste Episoden"},
                      {"category": "list_items", "title": _("Collections"), "url": self.getFullUrl("sammlungen")},
@@ -66,13 +73,46 @@ class SerienStreamTo(CBaseHostClass):
     def _useLegacyTitles(self):
         return config.plugins.iptvplayer.serienstreamto_legacy_titles.value
 
+    def _getWatchedKeyForItem(self, cItem):
+        #printDBG("SerienStreamTo._getWatchedKeyForItem")
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            itemType = str(cItem.get("type", "") or "").strip()
+            category = str(cItem.get("category", "") or "").strip()
+            if itemType in ["video", "audio"]:
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "url:%s" % url
+            if category == "list_episodes":
+                seriesUrl = str(cItem.get("series_url", "") or "").strip()
+                seasonNum = str(cItem.get("season_num", "") or "").strip()
+                if seriesUrl == "" or seasonNum == "":
+                    return ""
+                return "season:%s|%s" % (seriesUrl, seasonNum)
+            if category == "list_seasons":
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "series:%s" % url
+            if category == "list_newepisodes":
+                url = str(cItem.get("url", "") or "").strip()
+                if url == "":
+                    return ""
+                return "url:%s" % url
+            return ""
+        except Exception:
+            printExc()
+            return ""
+
     def getPage(self, baseUrl, addParams=None, post_data=None):
         if addParams is None:
             addParams = dict(self.defaultParams)
         return self.cm.getPageCFProtection(baseUrl, addParams, post_data)
 
     def getJumpItem(self, max_page, page, url, name):
-        name = (name or "category").split("-")[0] + "-JUMP"
+        name = (name or "category").split('-')[0] + "-JUMP"
         if max_page:
             return {"good_for_fav": False, "title": "%s %s/%s" % (_("Jump"), page, max_page),
                     "desc": _("Jump to a selected page, max: {}").format(max_page),
@@ -207,6 +247,7 @@ class SerienStreamTo(CBaseHostClass):
             params.update({"good_for_fav": True, "category": "list_seasons", "title": self.cleanHtmlStr(title), "url": url, "icon": icon, "desc": ""})
             if "sammlung" in url:
                 params.update({"category": "list_items"})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addDir(params)
         if max_page and max_page > 1:
             self.addDir({"title": "************************", "category": "empty"})
@@ -237,7 +278,7 @@ class SerienStreamTo(CBaseHostClass):
         printDBG("IMDb DEBUG listSeasons id=[%s]" % imdb_id)
         imdb_rating = self.getIMDBRating(imdb_id) if imdb_id else "-"
         printDBG("IMDb DEBUG listSeasons rating=[%s]" % imdb_rating)
-        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'id="season-nav">', "</nav>")
+        data = self.cm.ph.getAllItemsBeetwenMarkers(data, 'id="season-nav">', "</ul>")
         if not data:
             return
         data = re.compile(r'href="([^"]+).*?data-season-pill="(\d+)', re.DOTALL).findall(data[0])
@@ -247,10 +288,12 @@ class SerienStreamTo(CBaseHostClass):
             desc_show = desc + imdb_text
             params = dict(cItem)
             params.update({"good_for_fav": True, "category": "list_episodes", "title": title,
-                           "url": self.getFullUrl(url), "icon": icon, "desc": desc_show,
-                           "imdb_rating": imdb_rating, "imdb_id": imdb_id, "imdb_lookup_url": self.getFullUrl(url)})
+            "url": self.getFullUrl(url), "icon": icon, "desc": desc_show,
+            "imdb_rating": imdb_rating, "imdb_id": imdb_id, "imdb_lookup_url": self.getFullUrl(url),
+            "series_url": cItem.get("url", ""), "season_num": str(se)})
             if trailer:
                 params.update({"trailer": trailer})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addDir(params)
 
     def listEpisodes(self, cItem):
@@ -269,10 +312,12 @@ class SerienStreamTo(CBaseHostClass):
                 ep_prefix = "" if ("Episode" in name or "Folge" in name) else "%s %s - " % (_("Episode"), ep)
                 title = "%s - %s%s %s" % (cItem["title"], ep_prefix, name, language(item))
             else:
-                season_num = self.cm.ph.getSearchGroups(cItem.get("title", ""), r"Staffel\s+(\d+)")[0]
+                season_num = str(cItem.get("season_num", ""))
                 if not season_num:
-                    season_num = self.cm.ph.getSearchGroups(cItem.get("url", ""), r"/staffel-(\d+)")[0]
-                season_num = int(season_num) if season_num.isdigit() else 0
+                    season_num = self.cm.ph.getSearchGroups(cItem.get("title", ""), r'Staffel\s+(\d+)')[0]
+                if not season_num:
+                    season_num = self.cm.ph.getSearchGroups(cItem.get("url", ""), r'/staffel-(\d+)')[0]
+                season_num = int(season_num) if str(season_num).isdigit() else 0
                 series_title = cItem.get("title", "").split(" - Staffel")[0].strip()
                 ep_num = int(ep) if ep.isdigit() else 0
                 se_tag = "S%02dE%02d" % (season_num, ep_num) if season_num > 0 and ep_num > 0 else ""
@@ -280,7 +325,11 @@ class SerienStreamTo(CBaseHostClass):
                 lang_suffix = " - %s" % lang if lang else ""
                 title = "%s - %s - %s%s" % (series_title, se_tag, name, lang_suffix) if se_tag else "%s - %s%s" % (series_title, name, lang_suffix)
             params = dict(cItem)
-            params.update({"good_for_fav": True, "title": title, "url": url, "imdb_lookup_url": cItem.get("imdb_lookup_url", "") or cItem.get("url", "")})
+            params.update({"good_for_fav": True, "title": title, "url": url, "type": "video",
+            "imdb_lookup_url": cItem.get("imdb_lookup_url", "") or cItem.get("url", ""),
+            "series_url": cItem.get("series_url", "") or cItem.get("url", ""),
+            "season_num": str(cItem.get("season_num", ""))})
+            self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
             self.addVideo(params)
 
     def listNewEpisodes(self, cItem):
@@ -300,13 +349,14 @@ class SerienStreamTo(CBaseHostClass):
                 if self._useLegacyTitles():
                     title = "%s - %s - %s%s" % (name, se, ep, (" %s" % lang if lang else ""))
                 else:
-                    season_num = self.cm.ph.getSearchGroups(se, r"(\d+)")[0]
-                    episode_num = self.cm.ph.getSearchGroups(ep, r"(\d+)")[0]
+                    season_num = self.cm.ph.getSearchGroups(se, r'(\d+)')[0]
+                    episode_num = self.cm.ph.getSearchGroups(ep, r'(\d+)')[0]
                     season_ep = "S%sE%s" % (season_num.zfill(2), episode_num.zfill(2)) if season_num and episode_num else "%s %s" % (se, ep)
                     title = "%s - %s%s" % (name, season_ep, (" - %s" % lang) if lang else "")
-                imdb_lookup_url = re.sub(r"/staffel-\d+/episode-\d+/?$", "/", url)
+                imdb_lookup_url = re.sub(r'/staffel-\d+/episode-\d+/?$', '/', url)
                 params = dict(cItem)
                 params.update({"good_for_fav": False, "title": title, "url": url, "icon": icon, "imdb_id": "", "imdb_rating": "-", "imdb_lookup_url": imdb_lookup_url})
+                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
                 self.addVideo(params)
 
     def listValue(self, cItem):
@@ -324,6 +374,7 @@ class SerienStreamTo(CBaseHostClass):
                 dub.add(url)
                 params = dict(cItem)
                 params.update({"good_for_fav": True, "category": "list_items", "title": self.cleanHtmlStr(title), "url": self.getFullUrl(url)})
+                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
                 self.addDir(params)
 
     def listSearchResult(self, cItem, searchPattern, searchType):
@@ -334,6 +385,10 @@ class SerienStreamTo(CBaseHostClass):
 
     def getLinksForVideo(self, cItem):
         printDBG("SerienStreamTo.getLinksForVideo [%s]" % cItem)
+        try:
+            self.watchedHelper.markHostItemAsWatched(self, cItem, self._getWatchedKeyForItem)
+        except Exception:
+            printExc()
         urltab = []
         sidecarTxt = ""
         sidecarImg = ""
@@ -423,10 +478,8 @@ class SerienStreamTo(CBaseHostClass):
         cfgSidecarEnabled = config.plugins.iptvplayer.serienstreamto_sidecar.value
         cfgMkvEnabled = config.plugins.iptvplayer.serienstreamto_mkv.value
         sidecar = sidecarFromUrlMeta(url, cfgSidecarEnabled)
-
         def _addFinalMeta(videoLinks):
             return decorateResolvedLinkItems(videoLinks, sidecar=sidecar, mkvEnabled=cfgMkvEnabled)
-
         if "youtube" in url:
             return _addFinalMeta(self.up.getVideoLinkExt(url))
         params = dict(self.defaultParams)
@@ -548,6 +601,57 @@ class SerienStreamTo(CBaseHostClass):
 class IPTVHost(CHostBase):
     def __init__(self):
         CHostBase.__init__(self, SerienStreamTo(), True, [])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('serienstreamto')
+
+    def getFavouriteHostName(self, index, displayItem):
+        return 'serienstreamto'
+
+    def fixWatchedFlag(self, ret):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+            ret = self.watchedHelper.fixHostRet(ret, self.host.currList, self.host._getWatchedKeyForItem, self.getFavouriteHostName)
+        self.cachedRet = ret
+        return ret
+
+    def syncWatchedToFavouriteHash(self, Index=0):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value and self.watchedHelper.syncFavouriteFromRet(self.cachedRet, Index, self.getFavouriteHostName):
+            self.refreshAfterWatchedFlagChange = True
+            return True
+        return False
+
+    def getLinksForVideo(self, Index=0, selItem=None):
+        try:
+            if config.plugins.iptvplayer.favourites_use_watched_flag.value and Index < len(self.host.currList):
+                self.watchedHelper.markHostItemAsWatched(self.host, self.host.currList[Index], self.host._getWatchedKeyForItem)
+        except Exception:
+            printExc()
+        try:
+            self.syncWatchedToFavouriteHash(Index)
+        except Exception:
+            printExc()
+        return CHostBase.getLinksForVideo(self, Index, selItem)
+
+    def getListForItem(self, Index=0, refresh=0, selItem=None):
+        ret = CHostBase.getListForItem(self, Index, refresh, selItem)
+        return self.fixWatchedFlag(ret)
+
+    def getPrevList(self, refresh=0):
+        ret = CHostBase.getPrevList(self, refresh)
+        return self.fixWatchedFlag(ret)
+
+    def getCurrentList(self, refresh=0):
+        if refresh == 1 and self.refreshAfterWatchedFlagChange and self.cachedRet is not None:
+            ret = self.cachedRet
+        else:
+            ret = CHostBase.getCurrentList(self, refresh)
+        ret = self.fixWatchedFlag(ret)
+        self.refreshAfterWatchedFlagChange = False
+        return ret
+
+    def getMoreForItem(self, Index=0):
+        ret = CHostBase.getMoreForItem(self, Index)
+        return self.fixWatchedFlag(ret)
 
     def withArticleContent(self, cItem):
         return cItem["category"] in ["video", "list_seasons", "list_episodes", "list_newepisodes"]

--- a/IPTVPlayer/hosts/hostyoutube.py
+++ b/IPTVPlayer/hosts/hostyoutube.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified: 25.07.2026  - Change added YouTube user links support for channel search results, including add-to-user-links action,
-# folder selection or new folder creation, and user links editor integration via ytlist.txt; moved to separate youtubeuserlinks.py
-# to keep hostyoutube.py cleaner, URL meta helper for sidecar and MKV postprocess handling - Kamikaze24
+# Last Modified: 05.08.2026  - Centralized watched helper integration incl. favourite hash sync - Kamikaze24
 ###################################################
 # LOCAL import
 ###################################################
@@ -14,6 +12,7 @@ from Plugins.Extensions.IPTVPlayer.libs.youtubeparser import YouTubeParser
 from Plugins.Extensions.IPTVPlayer.p2p3.UrlLib import urllib_quote_plus
 from Plugins.Extensions.IPTVPlayer.libs.urlmetahelper import buildSidecar, buildYoutubeOptions, decorateYoutubeUrl, decorateYoutubeLinkItems
 from Plugins.Extensions.IPTVPlayer.libs.youtubeuserlinks import YouTubeUserLinksManager
+from Plugins.Extensions.IPTVPlayer.tools.iptvwatchedhelper import IPTVWatchedHelper
 
 ###################################################
 
@@ -61,6 +60,7 @@ config.plugins.iptvplayer.youtube_ui_language = ConfigSelection(
         ("en", _("English")),
     ],
 )
+config.plugins.iptvplayer.favourites_use_watched_flag = ConfigYesNo(default=True)
 
 
 try:
@@ -88,6 +88,9 @@ def GetConfigList():
     optionList.append(getConfigListEntry(_("Create sidecar files (.txt/.jpg)") + ":", config.plugins.iptvplayer.youtube_sidecar))
     optionList.append(getConfigListEntry(_("Create MKV with chapter marks from description") + ":", config.plugins.iptvplayer.youtube_mkv_chapters))
     optionList.append(getConfigListEntry(_("Create Enigma2 .cuts chapter marks") + ":", config.plugins.iptvplayer.youtube_enigma2_cuts))
+    optionList.append(getConfigListEntry(_("Allow watched flag to be set"), config.plugins.iptvplayer.favourites_use_watched_flag))
+    if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+        optionList.append(getConfigListEntry(_("The color of the viewed item"), config.plugins.iptvplayer.watched_item_color))
     # temporary, the ffmpeg must be in right version to be able to merge file without transcoding
     # checking should be moved to setup
     if IsExecutable("ffmpeg"):
@@ -232,6 +235,7 @@ class Youtube(CBaseHostClass):
         self.ytp = YouTubeParser()
         self.currFileHost = None
         self.userLinks = YouTubeUserLinksManager(self._getUserLinksPath, self._getCategory, self._extractChannelNameFromItem)
+        self.watchedHelper = IPTVWatchedHelper('youtube')
 
     def _getCategory(self, url):
         # printDBG("Youtube._getCategory")
@@ -266,7 +270,7 @@ class Youtube(CBaseHostClass):
         return videoId
 
     def _getVideoIdFromItem(self, cItem):
-        printDBG("Youtube._getVideoIdFromItem")
+        #printDBG("Youtube._getVideoIdFromItem")
         videoId = ""
         try:
             videoId = cItem.get("video_id", "")
@@ -403,6 +407,29 @@ class Youtube(CBaseHostClass):
     def _getUserLinksPath(self):
         return os.path.join(config.plugins.iptvplayer.Sciezkaurllist.value, self.UTLIST_FILE)
 
+    def _getWatchedKeyForItem(self, cItem):
+        #printDBG("Youtube._getWatchedKeyForItem")
+        try:
+            if not isinstance(cItem, dict):
+                return ""
+            if cItem.get("is_pagination", False):
+                return ""
+            if cItem.get("type", "") == "more" or cItem.get("image_type", "") == "NEXT":
+                return ""
+            category = cItem.get("category", "")
+            if category not in ["video", "movie", "traylist"] and cItem.get("type", "") not in ["video", "audio"]:
+                if "watch?v=" not in cItem.get("url", "") and not cItem.get("video_id", ""):
+                    return ""
+            videoId = self._getVideoIdFromItem(cItem)
+            if videoId:
+                return "videoid:%s" % videoId
+            url = str(cItem.get("url", "") or "").strip().replace("&amp;", "&")
+            if url:
+                return "url:%s" % url
+        except Exception:
+            printExc()
+        return ""
+
     def readUserLinks(self):
         return self.userLinks.read()
 
@@ -515,6 +542,7 @@ class Youtube(CBaseHostClass):
                     params = dict(cItem)
                     category = self._getCategory(item["url"])
                     params.update({"good_for_fav": True, "title": item["full_title"], "url": item["url"], "desc": item["url"], "category": category})
+                    self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
                     if "video" == category:
                         self.addVideo(params)
                     elif "more" == category:
@@ -532,6 +560,7 @@ class Youtube(CBaseHostClass):
                     params = dict(cItem)
                     category = self._getCategory(item["url"])
                     params.update({"good_for_fav": True, "title": title, "url": item["url"], "desc": item["url"], "category": category})
+                    self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
                     if "video" == category:
                         self.addVideo(params)
                     elif "more" == category:
@@ -619,6 +648,7 @@ class Youtube(CBaseHostClass):
                 desc += E2ColoR("yellow") + _("Views") + E2ColoR("white") + ":" + self.cm.ph.getDataBeetwenMarkers(item, '"viewCountText":{"simpleText":"', '"},"navigationEndpoint":', False)[1]
                 params = {"title": title, "url": url, "icon": icon, "desc": desc, "video_id": self._extractVideoId(url)}
                 self._injectChannelNameToItem(params)
+                self.watchedHelper.updateHostItemFlag(self, params, self._getWatchedKeyForItem)
                 self.addVideo(params)
             return
 
@@ -656,6 +686,7 @@ class Youtube(CBaseHostClass):
                 tmp = self.ytp.getVideosFromChannelList(url, category, page, cItem)
                 if len(tmp) > 0:
                     self._injectChannelNameToItems(tmp, defaultChannel)
+                    self.watchedHelper.updateHostListFlags(self, tmp, self._getWatchedKeyForItem)
                     params = {"good_for_fav": False, "category": "sub_items", "title": _("Videos"), "sub_items": tmp}
                     self.addDir(params)
 
@@ -663,11 +694,13 @@ class Youtube(CBaseHostClass):
                 tmp = self.ytp.getVideosFromChannelList(url, category, page, cItem)
                 if len(tmp) > 0:
                     self._injectChannelNameToItems(tmp, defaultChannel)
+                    self.watchedHelper.updateHostListFlags(self, tmp, self._getWatchedKeyForItem)
                     params = {"good_for_fav": False, "category": "sub_items", "title": _("Live streams"), "sub_items": tmp}
                     self.addDir(params)
             else:
                 self.currList = self.ytp.getVideosFromChannelList(url, category, page, cItem)
                 self._injectChannelNameToItems(self.currList, defaultChannel)
+                self.watchedHelper.updateHostListFlags(self, self.currList, self._getWatchedKeyForItem)
         elif "playlist" == category:
             self.currList = self.ytp.getVideosApiPlayList(url, category, page, cItem)
         elif "traylist" == category:
@@ -688,6 +721,7 @@ class Youtube(CBaseHostClass):
         for item in tmpList:
             item.update({"name": "category"})
             if "video" == item["type"]:
+                self.watchedHelper.updateHostItemFlag(self, item, self._getWatchedKeyForItem)
                 self.addVideo(item)
             elif "more" == item["type"]:
                 item.update({"image_type": "NEXT"})
@@ -709,6 +743,12 @@ class Youtube(CBaseHostClass):
         channelName = ""
 
         workItem = dict(cItem)
+
+        try:
+            self.watchedHelper.markHostItemAsWatched(self, workItem, self._getWatchedKeyForItem)
+            self.watchedHelper.markHostItemAsWatched(self, cItem, self._getWatchedKeyForItem)
+        except Exception:
+            printExc()
 
         try:
             if workItem.get("is_pagination", False) or workItem.get("type", "") == "more" or workItem.get("image_type", "") == "NEXT":
@@ -971,6 +1011,24 @@ class IPTVHost(CHostBase):
 
     def __init__(self):
         CHostBase.__init__(self, Youtube(), True, [CDisplayListItem.TYPE_VIDEO, CDisplayListItem.TYPE_AUDIO])
+        self.cachedRet = None
+        self.refreshAfterWatchedFlagChange = False
+        self.watchedHelper = IPTVWatchedHelper('youtube')
+
+    def getFavouriteHostName(self, index, displayItem):
+        return "youtube"
+
+    def fixWatchedFlag(self, ret):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value:
+            ret = self.watchedHelper.fixHostRet(ret, self.host.currList, self.host._getWatchedKeyForItem, self.getFavouriteHostName)
+        self.cachedRet = ret
+        return ret
+
+    def syncWatchedToFavouriteHash(self, Index=0):
+        if config.plugins.iptvplayer.favourites_use_watched_flag.value and self.watchedHelper.syncFavouriteFromRet(self.cachedRet, Index, self.getFavouriteHostName):
+            self.refreshAfterWatchedFlagChange = True
+            return True
+        return False
 
     def getSearchTypes(self):
         return self.host.SEARCH_TYPES
@@ -999,7 +1057,7 @@ class IPTVHost(CHostBase):
         except Exception:
             printExc()
         return False
-
+    
     def withArticleContent(self, cItem):
         try:
             category = cItem.get("category", "")
@@ -1020,3 +1078,36 @@ class IPTVHost(CHostBase):
             printExc()
             retCode = RetHost.ERROR
         return RetHost(retCode, value=retlist)
+
+    def getLinksForVideo(self, Index=0, selItem=None):
+        try:
+            if config.plugins.iptvplayer.favourites_use_watched_flag.value and Index < len(self.host.currList):
+                self.watchedHelper.markHostItemAsWatched(self.host, self.host.currList[Index], self.host._getWatchedKeyForItem)
+        except Exception:
+            printExc()
+        try:
+            self.syncWatchedToFavouriteHash(Index)
+        except Exception:
+            printExc()
+        return CHostBase.getLinksForVideo(self, Index, selItem)
+
+    def getListForItem(self, Index=0, refresh=0, selItem=None):
+        ret = CHostBase.getListForItem(self, Index, refresh, selItem)
+        return self.fixWatchedFlag(ret)
+
+    def getPrevList(self, refresh=0):
+        ret = CHostBase.getPrevList(self, refresh)
+        return self.fixWatchedFlag(ret)
+
+    def getCurrentList(self, refresh=0):
+        if refresh == 1 and self.refreshAfterWatchedFlagChange and self.cachedRet is not None:
+            ret = self.cachedRet
+        else:
+            ret = CHostBase.getCurrentList(self, refresh)
+        ret = self.fixWatchedFlag(ret)
+        self.refreshAfterWatchedFlagChange = False
+        return ret
+
+    def getMoreForItem(self, Index=0):
+        ret = CHostBase.getMoreForItem(self, Index)
+        return self.fixWatchedFlag(ret)

--- a/IPTVPlayer/tools/iptvwatchedhelper.py
+++ b/IPTVPlayer/tools/iptvwatchedhelper.py
@@ -1,0 +1,453 @@
+# -*- coding: utf-8 -*-
+# added: 05.08.2026 - central watched helper for normal items, host lists and favourites, file based watched flag handling via hashed keys, item/list/host state updates, favourite hash synchronization, season/series parent propagation for episode items, grouped debug call handling and central config based write protection - Kamikaze24
+###################################################
+# LOCAL import
+###################################################
+from Plugins.Extensions.IPTVPlayer.tools.iptvtools import printDBG, printExc, GetFavouritesDir, mkdirs, touch, rm
+from Plugins.Extensions.IPTVPlayer.libs.crypto.hash.md5Hash import MD5
+###################################################
+from Plugins.Extensions.IPTVPlayer.p2p3.pVer import isPY2
+###################################################
+
+###################################################
+# FOREIGN import
+###################################################
+from Tools.Directories import fileExists
+from binascii import hexlify
+import os
+from Components.config import config
+
+
+class IPTVWatchedHelper(object):
+
+    def __init__(self, hostName=''):
+        self.hostName = str(hostName or '')
+        self._favouritesBaseDir = None
+        self._watchedBaseDir = None
+        self._ensuredDirs = {}
+        self._debugCalls = {}
+        self._debugEnabled = True
+
+    ###################################################
+    # debug helpers
+    ###################################################
+    def _dbgCall(self, name):
+        try:
+            if not self._debugEnabled:
+                return
+            self._debugCalls[name] = self._debugCalls.get(name, 0) + 1
+        except Exception:
+            printExc()
+
+    def dumpDebugCalls(self, prefix='IPTVWatchedHelper'):
+        try:
+            if not self._debugEnabled or self._debugCalls == {}:
+                return
+            keys = sorted(self._debugCalls.keys())
+            parts = []
+            for key in keys:
+                parts.append('%s.%s x%d' % (prefix, key, self._debugCalls[key]))
+            printDBG(' | '.join(parts))
+            self._debugCalls = {}
+        except Exception:
+            printExc()
+
+    def setDebugEnabled(self, enabled):
+        try:
+            self._debugEnabled = bool(enabled)
+        except Exception:
+            printExc()
+
+    ###################################################
+    # normalization helpers
+    ###################################################
+    def _normalizeKey(self, watchedKey):
+        try:
+            watchedKey = str(watchedKey or '').strip()
+            return watchedKey
+        except Exception:
+            printExc()
+            return ''
+
+    def _normalizeHostName(self, hostName=None):
+        try:
+            if hostName in [None, '']:
+                hostName = self.hostName
+            hostName = str(hostName or '').strip()
+            return hostName
+        except Exception:
+            printExc()
+            return ''
+
+    def _hashString(self, value):
+        try:
+            hashAlg = MD5()
+            hashData = hexlify(hashAlg(str(value or '')))
+            if not isPY2():
+                hashData = hashData.decode()
+            return hashData
+        except Exception:
+            printExc()
+            return ''
+
+    ###################################################
+    # path helpers
+    ###################################################
+    def _getFavouritesBaseDir(self):
+        try:
+            if self._favouritesBaseDir is None:
+                self._favouritesBaseDir = GetFavouritesDir('').rstrip('/')
+            return self._favouritesBaseDir
+        except Exception:
+            printExc()
+            return ''
+
+    def _getWatchedBaseDir(self):
+        try:
+            if self._watchedBaseDir is None:
+                baseDir = self._getFavouritesBaseDir()
+                if baseDir == '':
+                    return ''
+                self._watchedBaseDir = os.path.join(baseDir, 'IPTVWatched')
+            return self._watchedBaseDir
+        except Exception:
+            printExc()
+            return ''
+
+    ###################################################
+    # config helpers
+    ###################################################
+    def isMarkingAllowed(self):
+        try:
+            return bool(config.plugins.iptvplayer.favourites_use_watched_flag.value)
+        except Exception:
+            printExc()
+        return False
+
+    ###################################################
+    # watched file helpers
+    ###################################################
+    def getWatchedFilePath(self, watchedKey):
+        self._dbgCall('getWatchedFilePath')
+        try:
+            watchedKey = self._normalizeKey(watchedKey)
+            hostName = self._normalizeHostName()
+            if watchedKey == '' or hostName == '':
+                return ''
+            hashData = self._hashString(watchedKey)
+            if hashData == '':
+                return ''
+            baseDir = self._getWatchedBaseDir()
+            if baseDir == '':
+                return ''
+            return os.path.join(baseDir, hostName, '.%s.iptvhash' % hashData)
+        except Exception:
+            printExc()
+            return ''
+
+    def _ensureWatchedDir(self, hostName=None):
+        try:
+            hostName = self._normalizeHostName(hostName)
+            if hostName == '':
+                return False
+            dirPath = os.path.join(self._getWatchedBaseDir(), hostName)
+            if dirPath == '':
+                return False
+            if self._ensuredDirs.get(dirPath, False):
+                return True
+            sts = mkdirs(dirPath)
+            if sts:
+                self._ensuredDirs[dirPath] = True
+            return sts
+        except Exception:
+            printExc()
+            return False
+
+    ###################################################
+    # watched state helpers
+    ###################################################
+    def isWatched(self, watchedKey):
+        self._dbgCall('isWatched')
+        try:
+            flagFilePath = self.getWatchedFilePath(watchedKey)
+            if flagFilePath != '':
+                return fileExists(flagFilePath)
+        except Exception:
+            printExc()
+        return False
+
+    def markItemWatched(self, item, watchedKey):
+        self._dbgCall('markItemWatched')
+        try:
+            if not self.isMarkingAllowed():
+                return False
+            watchedKey = self._normalizeKey(watchedKey)
+            if watchedKey == '':
+                return False
+            if not self._ensureWatchedDir():
+                return False
+            flagFilePath = self.getWatchedFilePath(watchedKey)
+            if flagFilePath == '':
+                return False
+            if touch(flagFilePath):
+                try:
+                    item['isWatched'] = True
+                except Exception:
+                    printExc()
+                return True
+        except Exception:
+            printExc()
+        return False
+
+    def unmarkItemWatched(self, item, watchedKey):
+        self._dbgCall('unmarkItemWatched')
+        try:
+            watchedKey = self._normalizeKey(watchedKey)
+            if watchedKey == '':
+                return False
+            flagFilePath = self.getWatchedFilePath(watchedKey)
+            if flagFilePath == '':
+                return False
+            if rm(flagFilePath):
+                try:
+                    item['isWatched'] = False
+                except Exception:
+                    printExc()
+                return True
+        except Exception:
+            printExc()
+        return False
+
+    ###################################################
+    # item update helpers
+    ###################################################
+    def updateItemFlag(self, item, watchedKey):
+        self._dbgCall('updateItemFlag')
+        try:
+            item['isWatched'] = self.isWatched(watchedKey)
+        except Exception:
+            printExc()
+            try:
+                item['isWatched'] = False
+            except Exception:
+                printExc()
+        return item
+
+    def updateListFlags(self, itemList, keyProvider):
+        self._dbgCall('updateListFlags')
+        try:
+            for item in itemList:
+                try:
+                    watchedKey = keyProvider(item)
+                except Exception:
+                    watchedKey = ''
+                    printExc()
+                if watchedKey == '':
+                    try:
+                        item['isWatched'] = False
+                    except Exception:
+                        printExc()
+                else:
+                    self.updateItemFlag(item, watchedKey)
+        except Exception:
+            printExc()
+        return itemList
+
+    def updateHostItemFlag(self, host, cItem, keyProvider):
+        self._dbgCall('updateHostItemFlag')
+        try:
+            watchedKey = keyProvider(cItem)
+            if watchedKey == '':
+                cItem['isWatched'] = False
+            else:
+                self.updateItemFlag(cItem, watchedKey)
+        except Exception:
+            printExc()
+        return cItem
+
+    def updateHostListFlags(self, host, itemList, keyProvider):
+        self._dbgCall('updateHostListFlags')
+        try:
+            self.updateListFlags(itemList, keyProvider)
+        except Exception:
+            printExc()
+        self.dumpDebugCalls()
+        return itemList
+
+    def markHostItemAsWatched(self, host, cItem, keyProvider):
+        self._dbgCall('markHostItemAsWatched')
+        try:
+            if not self.isMarkingAllowed():
+                return False
+            watchedKey = keyProvider(cItem)
+            if watchedKey != '':
+                self.markItemWatched(cItem, watchedKey)
+            if isinstance(cItem, dict):
+                seriesUrl = str(cItem.get('series_url', '') or '').strip()
+                seasonNum = str(cItem.get('season_num', '') or '').strip()
+                if seriesUrl != '' and seasonNum != '':
+                    seasonItem = {'category': 'list_episodes', 'url': cItem.get('url', ''), 'series_url': seriesUrl, 'season_num': seasonNum}
+                    seasonKey = keyProvider(seasonItem)
+                    if seasonKey != '':
+                        self.markItemWatched(seasonItem, seasonKey)
+                if seriesUrl != '':
+                    seriesItem = {'category': 'list_seasons', 'url': seriesUrl}
+                    seriesKey = keyProvider(seriesItem)
+                    if seriesKey != '':
+                        self.markItemWatched(seriesItem, seriesKey)
+            return True
+        except Exception:
+            printExc()
+        return False
+
+    def unmarkHostItemAsWatched(self, host, cItem, keyProvider):
+        self._dbgCall('unmarkHostItemAsWatched')
+        try:
+            watchedKey = keyProvider(cItem)
+            if watchedKey == '':
+                return False
+            return self.unmarkItemWatched(cItem, watchedKey)
+        except Exception:
+            printExc()
+        return False
+
+    ###################################################
+    # favourite helpers
+    ###################################################
+    def getFavouriteHashData(self, hostName, displayItem):
+        self._dbgCall('getFavouriteHashData')
+        try:
+            hostName = self._normalizeHostName(hostName)
+            if hostName == '' or displayItem is None:
+                return None
+            hashSrc = '%s_%s' % (str(displayItem.name), str(displayItem.type))
+            hashData = self._hashString(hashSrc)
+            if hashData == '':
+                return None
+            return (hostName, hashData)
+        except Exception:
+            printExc()
+            return None
+
+    def getFavouriteHashFilePath(self, hostName, displayItem):
+        self._dbgCall('getFavouriteHashFilePath')
+        try:
+            hashData = self.getFavouriteHashData(hostName, displayItem)
+            if hashData is None:
+                return ''
+            baseDir = self._getWatchedBaseDir()
+            if baseDir == '':
+                return ''
+            return os.path.join(baseDir, hashData[0], '.%s.iptvhash' % hashData[1])
+        except Exception:
+            printExc()
+            return ''
+
+    def isFavouriteItemWatched(self, hostName, displayItem):
+        self._dbgCall('isFavouriteItemWatched')
+        try:
+            flagFilePath = self.getFavouriteHashFilePath(hostName, displayItem)
+            if flagFilePath != '':
+                return fileExists(flagFilePath)
+        except Exception:
+            printExc()
+        return False
+
+    def markFavouriteItemWatched(self, hostName, displayItem):
+        self._dbgCall('markFavouriteItemWatched')
+        try:
+            if not self.isMarkingAllowed():
+                return False
+            hostName = self._normalizeHostName(hostName)
+            if hostName == '' or displayItem is None:
+                return False
+            if not self._ensureWatchedDir(hostName):
+                return False
+            flagFilePath = self.getFavouriteHashFilePath(hostName, displayItem)
+            if flagFilePath == '':
+                return False
+            return touch(flagFilePath)
+        except Exception:
+            printExc()
+        return False
+
+    def unmarkFavouriteItemWatched(self, hostName, displayItem):
+        self._dbgCall('unmarkFavouriteItemWatched')
+        try:
+            flagFilePath = self.getFavouriteHashFilePath(hostName, displayItem)
+            if flagFilePath == '':
+                return False
+            return rm(flagFilePath)
+        except Exception:
+            printExc()
+        return False
+
+    ###################################################
+    # ret/favourite sync helpers
+    ###################################################
+    def updateFavouriteDisplayItemFlag(self, hostName, displayItem):
+        self._dbgCall('updateFavouriteDisplayItemFlag')
+        try:
+            displayItem.isWatched = self.isFavouriteItemWatched(hostName, displayItem)
+        except Exception:
+            printExc()
+        return displayItem
+
+    def updateFavouriteRetHostFlags(self, ret, hostNameProvider):
+        self._dbgCall('updateFavouriteRetHostFlags')
+        try:
+            if ret is None:
+                return ret
+            if not hasattr(ret, 'value') or ret.value is None:
+                return ret
+            for idx in range(len(ret.value)):
+                try:
+                    hostName = hostNameProvider(idx, ret.value[idx])
+                except Exception:
+                    hostName = ''
+                    printExc()
+                if hostName != '':
+                    self.updateFavouriteDisplayItemFlag(hostName, ret.value[idx])
+        except Exception:
+            printExc()
+        return ret
+
+    def fixHostRet(self, ret, currList, keyProvider, hostNameProvider):
+        self._dbgCall('fixHostRet')
+        try:
+            ret = self.updateFavouriteRetHostFlags(ret, hostNameProvider)
+        except Exception:
+            printExc()
+        try:
+            if ret is None or not hasattr(ret, 'value') or ret.value is None:
+                self.dumpDebugCalls()
+                return ret
+            for idx in range(len(ret.value)):
+                if currList is not None and idx < len(currList):
+                    try:
+                        watchedKey = keyProvider(currList[idx])
+                        if watchedKey != '':
+                            ret.value[idx].isWatched = self.isWatched(watchedKey)
+                    except Exception:
+                        printExc()
+        except Exception:
+            printExc()
+        self.dumpDebugCalls()
+        return ret
+
+    def syncFavouriteFromRet(self, cachedRet, index, hostNameProvider):
+        self._dbgCall('syncFavouriteFromRet')
+        try:
+            if cachedRet is None or not hasattr(cachedRet, 'value'):
+                return False
+            if index < 0 or index >= len(cachedRet.value):
+                return False
+            displayItem = cachedRet.value[index]
+            hostName = hostNameProvider(index, displayItem)
+            if self.markFavouriteItemWatched(hostName, displayItem):
+                cachedRet.value[index].isWatched = True
+                self.dumpDebugCalls()
+                return True
+        except Exception:
+            printExc()
+        return False

--- a/IPTVPlayer/version.py
+++ b/IPTVPlayer/version.py
@@ -2,4 +2,4 @@
 # YYYY.MM.DD.DAY_RELEASE
 # oe-mirrors Version
 
-IPTV_VERSION = "2026.08.02.01"
+IPTV_VERSION = "2026.08.05.01"


### PR DESCRIPTION
[iptvwatchedhelper]
* central watched helper for normal items, host lists and favourites, file based watched flag handling via hashed keys, item/list/host state updates, favourite hash synchronization, season/series parent propagation for episode items, grouped debug call handling and central config based write protection

[hostfilmpalast] [hostserienstreamto] [hostyoutube]
* Centralized watched helper integration incl. favourite hash sync - Kamikaze24

Thx to Kamikaze24